### PR TITLE
Allow building on NetBSD by using get_if_addrs-git

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 
 [dependencies]
 byteorder = "1.3"
-get_if_addrs = "0.5"
+get_if_addrs = { version = "0.5", git = "https://github.com/maidsafe-archive/get_if_addrs.git" }
 hostname = "0.3"
 log = "0.4"
 multimap = "0.8"


### PR DESCRIPTION
The relevant patch to `get_if_addrs` that allows building on NetBSD is _post-release_.
As `get_if_addrs` is archieved, the building of `libmdns` and subsequent build of `librespot` fail on NetBSD.

A way to overcome this is to use the git version of `get_if_addrs`. @snowkat has successfully built the package on NetBSD.
Please see, https://github.com/librespot-org/librespot/issues/520 for details.

Thanks!