### PR TITLE
Change get_if_addrs dependency to if-addrs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT"
 [dependencies]
 byteorder = "1.3"
 futures = "0.1"
-get_if_addrs = "0.5"
+if-addrs = "0.6"
 hostname = "0.3"
 log = "0.4"
 multimap = "0.8"

--- a/src/fsm.rs
+++ b/src/fsm.rs
@@ -1,7 +1,7 @@
 use dns_parser::{self, Name, QueryClass, QueryType, RRData};
 use futures::sync::mpsc;
 use futures::{Async, Future, Poll, Stream};
-use get_if_addrs::get_if_addrs;
+use if_addrs::get_if_addrs;
 use std::collections::VecDeque;
 use std::io;
 use std::io::ErrorKind::WouldBlock;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ extern crate log;
 
 extern crate byteorder;
 extern crate futures;
-extern crate get_if_addrs;
+extern crate if_addrs;
 extern crate hostname;
 extern crate multimap;
 extern crate net2;


### PR DESCRIPTION
if-addrs 0.6.0 includes some additional commits that weren't part of get_if_addrs 0.5.3, including support for NetBSD.

See also librespot-org/librespot#520.