### PR TITLE
Block shutdown until all pending messages are sent (Fixes #27).

### DIFF
--- a/examples/zeroconf_test.py
+++ b/examples/zeroconf_test.py
@@ -14,7 +14,11 @@ class MyListener:
         return name in self.found
 
     def add_service(self, zeroconf, type, name):
+        print(f"  Service {name} added")
         self.found.append(name.replace("." + TYPE, ""))
+
+    def remove_service(self, zeroconf, type, name):
+        print(f"  Service {name} removed")
 
 
 zeroconf = Zeroconf()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,14 +58,9 @@ impl Responder {
                     }
                 })
             })?;
-        let responder = rx.recv().expect("rx responder channel closed");
-        match responder{
-            Ok(mut responder) => {
-                responder.shutdown.1 = Some(join_handle);
-                return Ok(responder);
-            },
-            Err(err) => return Err(err),
-        }
+        let mut responder = rx.recv().expect("rx responder channel closed")?;
+        responder.shutdown.1 = Some(join_handle);
+        Ok(responder)
     }
 
     /// Spawn a `Responder` with the provided tokio `Handle`.


### PR DESCRIPTION
My first attempt didn't include a new sync_channel and I had expected that to be enough to make the Tokio runtime within the "mdns-responder" thread keep polling the futures until they all returned  `Poll::Ready(())`, _after_ first sending everything (specifically the goodbye messages) sitting in their outgoing queue. But that didn't work. It's as if the `block_on` call didn't actually block and prevent the thread from stopping before we are finished... I would very much like to hear from anyone who could explain why that is happening, I do not have a good grasp of Tokio, let alone Futures, or even Rust...

I would not be surprised to learn there's a far nicer way of doing this, but after much frustration this is where I ended up! Feel free to scrap this and implement a nicer fix.