### PR TITLE
Don't log ipv6 warning

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,10 +103,7 @@ impl Responder {
                 (Box::new(tasks), vec![v4_command, v6_command])
             }
 
-            (Ok((v4_task, v4_command)), Err(err)) => {
-                warn!("Failed to register IPv6 receiver: {:?}", err);
-                (Box::new(v4_task), vec![v4_command])
-            }
+            (Ok((v4_task, v4_command)), Err(err)) => (Box::new(v4_task), vec![v4_command]),
 
             (Err(err), _) => return Err(err),
         };


### PR DESCRIPTION
In my application i get this warning on startup, we expose the log to our user and it is not acceptable for us to spam the user with warnings.

If you don't want to accept this as is there are two other alternatives that i see. We could add a verbose flag that logs this warning or we could add an option to only start in ipv4 mode and then this could be a hard error if you ask for ipv6.

I could implement one of those options if you would like.
