### PR TITLE
Added allowed IP list in A record

### DIFF
--- a/examples/register_with_ip_list.rs
+++ b/examples/register_with_ip_list.rs
@@ -4,9 +4,9 @@ pub fn main() {
     builder.init();
 
     // allow only these two IP address to be sent in A record
-    let vec: Vec<std::net::IpAddr> = vec![ 
-        "192.168.1.10".parse::<std::net::Ipv4Addr>().unwrap().into(), 
-        std::net::Ipv6Addr::new(0, 0, 0, 0xfe80, 0x1ff, 0xfe23, 0x4567, 0x890a).into() 
+    let vec: Vec<std::net::IpAddr> = vec![
+        "192.168.1.10".parse::<std::net::Ipv4Addr>().unwrap().into(),
+        std::net::Ipv6Addr::new(0, 0, 0, 0xfe80, 0x1ff, 0xfe23, 0x4567, 0x890a).into(),
     ];
 
     let responder = libmdns::Responder::new_with_ip_list(vec).unwrap();

--- a/examples/register_with_ip_list.rs
+++ b/examples/register_with_ip_list.rs
@@ -1,0 +1,23 @@
+pub fn main() {
+    let mut builder = env_logger::Builder::new();
+    builder.parse_filters("libmdns=debug");
+    builder.init();
+
+    // allow only these two IP address to be sent in A record
+    let vec: Vec<std::net::IpAddr> = vec![ 
+        "192.168.1.10".parse::<std::net::Ipv4Addr>().unwrap().into(), 
+        std::net::Ipv6Addr::new(0, 0, 0, 0xfe80, 0x1ff, 0xfe23, 0x4567, 0x890a).into() 
+    ];
+
+    let responder = libmdns::Responder::new_with_ip_list(vec).unwrap();
+    let _svc = responder.register(
+        "_http._tcp".to_owned(),
+        "libmdns Web Server".to_owned(),
+        80,
+        &["path=/"],
+    );
+
+    loop {
+        ::std::thread::sleep(::std::time::Duration::from_secs(10));
+    }
+}

--- a/src/fsm.rs
+++ b/src/fsm.rs
@@ -37,12 +37,15 @@ pub struct FSM<AF: AddressFamily> {
     commands: mpsc::UnboundedReceiver<Command>,
     outgoing: VecDeque<(Vec<u8>, SocketAddr)>,
     _af: PhantomData<AF>,
-    allowed_ip: Vec<IpAddr>
+    allowed_ip: Vec<IpAddr>,
 }
 
 impl<AF: AddressFamily> FSM<AF> {
     // Will panic if called from outside the context of a runtime
-    pub fn new(services: &Services, allowed_ip: Vec<IpAddr>) -> io::Result<(FSM<AF>, mpsc::UnboundedSender<Command>)> {
+    pub fn new(
+        services: &Services,
+        allowed_ip: Vec<IpAddr>,
+    ) -> io::Result<(FSM<AF>, mpsc::UnboundedSender<Command>)> {
         let std_socket = AF::bind()?;
         let socket = UdpSocket::from_std(std_socket)?;
 
@@ -54,7 +57,7 @@ impl<AF: AddressFamily> FSM<AF> {
             commands: rx,
             outgoing: VecDeque::new(),
             _af: PhantomData,
-            allowed_ip: allowed_ip
+            allowed_ip: allowed_ip,
         };
 
         Ok((fsm, tx))
@@ -184,9 +187,9 @@ impl<AF: AddressFamily> FSM<AF> {
             }
 
             trace!("found interface {:?}", iface);
-            if !self.allowed_ip.is_empty() && !self.allowed_ip.contains( &iface.ip() ) { 
-	        trace!("  -> interface dropped");
-                continue 
+            if !self.allowed_ip.is_empty() && !self.allowed_ip.contains(&iface.ip()) {
+                trace!("  -> interface dropped");
+                continue;
             }
 
             match (iface.ip(), AF::DOMAIN) {

--- a/src/fsm.rs
+++ b/src/fsm.rs
@@ -37,11 +37,12 @@ pub struct FSM<AF: AddressFamily> {
     commands: mpsc::UnboundedReceiver<Command>,
     outgoing: VecDeque<(Vec<u8>, SocketAddr)>,
     _af: PhantomData<AF>,
+    allowed_ip: Vec<IpAddr>
 }
 
 impl<AF: AddressFamily> FSM<AF> {
     // Will panic if called from outside the context of a runtime
-    pub fn new(services: &Services) -> io::Result<(FSM<AF>, mpsc::UnboundedSender<Command>)> {
+    pub fn new(services: &Services, allowed_ip: Vec<IpAddr>) -> io::Result<(FSM<AF>, mpsc::UnboundedSender<Command>)> {
         let std_socket = AF::bind()?;
         let socket = UdpSocket::from_std(std_socket)?;
 
@@ -53,6 +54,7 @@ impl<AF: AddressFamily> FSM<AF> {
             commands: rx,
             outgoing: VecDeque::new(),
             _af: PhantomData,
+            allowed_ip: allowed_ip
         };
 
         Ok((fsm, tx))
@@ -182,6 +184,11 @@ impl<AF: AddressFamily> FSM<AF> {
             }
 
             trace!("found interface {:?}", iface);
+            if !self.allowed_ip.is_empty() && !self.allowed_ip.contains( &iface.ip() ) { 
+	        trace!("  -> interface dropped");
+                continue 
+            }
+
             match (iface.ip(), AF::DOMAIN) {
                 (IpAddr::V4(ip), Domain::IPV4) => {
                     builder = builder.add_answer(hostname, QueryClass::IN, ttl, &RRData::A(ip))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,8 @@ use std::cell::RefCell;
 use std::future::Future;
 use std::io;
 use std::marker::Unpin;
-use std::sync::{Arc, RwLock};
 use std::net::IpAddr;
+use std::sync::{Arc, RwLock};
 
 use std::thread;
 use tokio::{runtime::Handle, sync::mpsc};
@@ -93,7 +93,9 @@ impl Responder {
     pub fn with_default_handle() -> io::Result<(Responder, ResponderTask)> {
         Self::with_default_handle_and_ip_list(Vec::new())
     }
-    pub fn with_default_handle_and_ip_list(allowed_ip: Vec<IpAddr>) -> io::Result<(Responder, ResponderTask)> {
+    pub fn with_default_handle_and_ip_list(
+        allowed_ip: Vec<IpAddr>,
+    ) -> io::Result<(Responder, ResponderTask)> {
         let mut hostname = hostname::get()?.into_string().map_err(|_| {
             io::Error::new(io::ErrorKind::InvalidData, "Hostname not valid unicode")
         })?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use std::future::Future;
 use std::io;
 use std::marker::Unpin;
 use std::sync::{Arc, RwLock};
+use std::net::IpAddr;
 
 use std::thread;
 use tokio::{runtime::Handle, sync::mpsc};
@@ -41,6 +42,9 @@ type ResponderTask = Box<dyn Future<Output = ()> + Send + Unpin>;
 impl Responder {
     /// Spawn a responder task on an os thread.
     pub fn new() -> io::Result<Responder> {
+        Self::new_with_ip_list(Vec::new())
+    }
+    pub fn new_with_ip_list(allowed_ip: Vec<IpAddr>) -> io::Result<Responder> {
         let (tx, rx) = std::sync::mpsc::sync_channel(0);
         thread::Builder::new()
             .name("mdns-responder".to_owned())
@@ -50,7 +54,7 @@ impl Responder {
                     .build()
                     .unwrap();
                 rt.block_on(async {
-                    match Self::with_default_handle() {
+                    match Self::with_default_handle_and_ip_list(allowed_ip) {
                         Ok((responder, task)) => {
                             tx.send(Ok(responder)).expect("tx responder channel closed");
                             task.await;
@@ -77,13 +81,19 @@ impl Responder {
     /// # }
     /// ```
     pub fn spawn(handle: &Handle) -> io::Result<Responder> {
-        let (responder, task) = Self::with_default_handle()?;
+        Self::spawn_with_ip_list(handle, Vec::new())
+    }
+    pub fn spawn_with_ip_list(handle: &Handle, allowed_ip: Vec<IpAddr>) -> io::Result<Responder> {
+        let (responder, task) = Self::with_default_handle_and_ip_list(allowed_ip)?;
         handle.spawn(task);
         Ok(responder)
     }
 
     /// Spawn a `Responder` on the default tokio handle.
     pub fn with_default_handle() -> io::Result<(Responder, ResponderTask)> {
+        Self::with_default_handle_and_ip_list(Vec::new())
+    }
+    pub fn with_default_handle_and_ip_list(allowed_ip: Vec<IpAddr>) -> io::Result<(Responder, ResponderTask)> {
         let mut hostname = hostname::get()?.into_string().map_err(|_| {
             io::Error::new(io::ErrorKind::InvalidData, "Hostname not valid unicode")
         })?;
@@ -94,8 +104,8 @@ impl Responder {
 
         let services = Arc::new(RwLock::new(ServicesInner::new(hostname)));
 
-        let v4 = FSM::<Inet>::new(&services);
-        let v6 = FSM::<Inet6>::new(&services);
+        let v4 = FSM::<Inet>::new(&services, allowed_ip.clone());
+        let v6 = FSM::<Inet6>::new(&services, allowed_ip);
 
         let (task, commands): (ResponderTask, _) = match (v4, v6) {
             (Ok((v4_task, v4_command)), Ok((v6_task, v6_command))) => {


### PR DESCRIPTION
Added option to pass list of allowed IP list which can be sent in mDNS A records. By default libmdns adds IP of all available interfaces which not always is a required behaviour.