### PR TITLE
name: fix OOB panic on length exceeding data

### DIFF
--- a/src/dns_parser/name.rs
+++ b/src/dns_parser/name.rs
@@ -61,6 +61,9 @@ impl<'a> Name<'a> {
                 ));
             } else if byte & 0b1100_0000 == 0 {
                 let end = pos + byte as usize + 1;
+                if end >= data.len() {
+                    return Err(Error::UnexpectedEOF);
+                }
                 if from_utf8(&data[pos + 1..end]).is_err() {
                     return Err(Error::LabelIsNotAscii);
                 }

--- a/src/dns_parser/parser.rs
+++ b/src/dns_parser/parser.rs
@@ -121,6 +121,23 @@ mod test {
     }
 
     #[test]
+    fn parse_name_length_too_long_query() {
+        // If the name length provided in the query exceeds the available data we should error
+        // rather than panic.
+        //
+        // Here the entire data section contains only 17 bytes but the first name field length in
+        // the query section falsely indicates that the name field contains 17 bytes. If left
+        // unchecked this would cause:
+        // ```
+        // thread 'dns_parser::parser::test::parse_name_length_too_long_query' panicked at 'range
+        // end index 18 out of range for slice of length 17'
+        // ```
+        let query = b"\x06%\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\
+                      \x11example\x03com\x00\x00\x01\x00\x01";
+        assert!(Packet::parse(query).is_err());
+    }
+
+    #[test]
     fn parse_example_response() {
         let response = b"\x06%\x81\x80\x00\x01\x00\x01\x00\x00\x00\x00\
                          \x07example\x03com\x00\x00\x01\x00\x01\


### PR DESCRIPTION
Upon parsing a malformed DNS packet wherein the name field length increments the parser's position such that it exceeds the available data in the packet this will at present result in an out of range indexing panic.

While it would be best if such malformed panics did not exist, an mDNS responder can't control what requests it may receive from the network.

This seemed like a reasonable fix, but I'd be happy to work through any alternative solutions if another route is preferred.  Thanks in advance!