### PR TITLE
Add support for multiple network adapters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,8 @@ thiserror = "1.0"
 tokio = { version = "1.0", features = ["sync","net","rt"] }
 socket2 = { version = "0.4", features = ["all"] }
 
+[target.'cfg(not(windows))'.dependencies]
+nix = "0.23"
+
 [dev-dependencies]
 env_logger =  { version = "0.8", default-features = false, features = ["termcolor","humantime","atty"] }

--- a/src/address_family.rs
+++ b/src/address_family.rs
@@ -102,8 +102,7 @@ fn get_address_list() -> io::Result<Vec<(String, IpAddr)>> {
 }
 
 #[cfg(windows)]
-mod win
-{
+mod win {
     use std::ffi::{CString, NulError};
 
     mod private {


### PR DESCRIPTION
This is to address [https://github.com/librespot-org/libmdns/issues/33](https://github.com/librespot-org/libmdns/issues/33).

I have tested on Linux, macOS and Windows, but should work on most *nix OSs as the `nix` crate supports a lot of different OSs and architectures.