### PR TITLE
up recv buffer size to 64k

### DIFF
--- a/src/fsm.rs
+++ b/src/fsm.rs
@@ -68,7 +68,7 @@ impl<AF: AddressFamily> FSM<AF> {
     }
 
     fn recv_packets(&mut self, cx: &mut Context) -> io::Result<()> {
-        let mut recv_buf = [0u8; 4096];
+        let mut recv_buf = [0u8; 65536];
         let mut buf = tokio::io::ReadBuf::new(&mut recv_buf);
         loop {
             let addr = match self.socket.poll_recv_from(cx, &mut buf) {


### PR DESCRIPTION
Noticed that this error appears on Windows with a 4kb buffer. Increasing to 64kb seems to solve the issue.

`[ERROR] ResponderRecvPacket Error: 0s { code: 10040, kind: Uncategorized, message: "A message sent on a datagram socket was larger than the internal message buffer or some other network limit, or the buffer used to receive a datagram into was smaller than the datagram itself`