### PR TITLE
upgrade deps to latest versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,22 +10,26 @@ license = "MIT"
 edition = "2018"
 
 [dependencies]
-byteorder = "1.3"
-if-addrs = "0.7"
-hostname = "0.3"
+byteorder = "1.5.0"
+if-addrs = "0.10.2"
+hostname = "0.3.1"
 log = "0.4"
-multimap = "0.8"
+multimap = "0.9"
 rand = "0.8"
 futures-util = "0.3"
 thiserror = "1.0"
-tokio = { version = "1.0", features = ["sync","net","rt"] }
-socket2 = { version = "0.4", features = ["all"] }
+tokio = { version = "1.0", features = ["sync", "net", "rt"] }
+socket2 = { version = "0.5", features = ["all"] }
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["netioapi"] }
 
 [target.'cfg(not(windows))'.dependencies]
-nix = "0.23"
+nix = { version = "0.27", features = ["net"] }
 
 [dev-dependencies]
-env_logger =  { version = "0.8", default-features = false, features = ["termcolor","humantime","atty"] }
+env_logger = { version = "0.10", default-features = false, features = [
+  "color",
+  "humantime",
+  "auto-color",
+] }


### PR DESCRIPTION
Simple update of dependencies to make adopting this version of the crate more accessible. I could only execute the tests on my nix systems but it appears the dependency APIs have not changed.

Hope this is helpful!