### PR TITLE
Use the same cfg-gate on Socket::set_reuse_port as their documentation

### DIFF
--- a/src/address_family.rs
+++ b/src/address_family.rs
@@ -34,8 +34,7 @@ pub trait AddressFamily {
         socket.set_reuse_address(true)?;
         socket.set_nonblocking(true)?;
 
-        #[cfg(not(windows))]
-        #[cfg(not(target_os = "illumos"))]
+        #[cfg(all(unix, not(any(target_os = "solaris", target_os = "illumos"))))]
         socket.set_reuse_port(true)?;
 
         socket.bind(&addr)?;


### PR DESCRIPTION
This adds support for compiling on Solaris (once supported in `nix` and `if-addrs`).

See [`Socket::set_reuse_port`](https://docs.rs/socket2/latest/socket2/struct.Socket.html#method.set_reuse_port).